### PR TITLE
fix: version check compatibility with devel and .x suffixes

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -6121,7 +6121,10 @@ function checkVersion(versionSpec) {
         .replace(/\.x$/, '')
         .replace(/\s+devel$/, '')
         .trim();
-    const normalizedExpected = versionSpec.trim();
+    const normalizedExpected = versionSpec
+        .replace(/\.x$/, '')
+        .replace(/\s+devel$/, '')
+        .trim();
     // Compare major.minor parts for compatibility
     const actualParts = normalizedActual.split('.');
     const expectedParts = normalizedExpected.split('.');

--- a/dist/index.js
+++ b/dist/index.js
@@ -6115,7 +6115,20 @@ function install(xgoDir) {
 function checkVersion(versionSpec) {
     core.info(`Testing xgo ${versionSpec} ...`);
     const actualVersion = xgoVersion();
-    if (actualVersion !== versionSpec) {
+    // Normalize versions by removing common suffixes
+    // Examples: "1.5.x" -> "1.5", "1.6.0 devel" -> "1.6.0"
+    const normalizedActual = actualVersion
+        .replace(/\.x$/, '')
+        .replace(/\s+devel$/, '')
+        .trim();
+    const normalizedExpected = versionSpec.trim();
+    // Compare major.minor parts for compatibility
+    const actualParts = normalizedActual.split('.');
+    const expectedParts = normalizedExpected.split('.');
+    const minParts = Math.min(2, expectedParts.length);
+    const actualPrefix = actualParts.slice(0, minParts).join('.');
+    const expectedPrefix = expectedParts.slice(0, minParts).join('.');
+    if (actualPrefix !== expectedPrefix) {
         throw new Error(`Installed xgo version ${actualVersion} does not match expected version ${versionSpec}`);
     }
     core.info(`Installed xgo version ${actualVersion}`);

--- a/src/install-xgo.ts
+++ b/src/install-xgo.ts
@@ -109,7 +109,10 @@ function checkVersion(versionSpec: string): string {
     .replace(/\.x$/, '')
     .replace(/\s+devel$/, '')
     .trim()
-  const normalizedExpected = versionSpec.trim()
+  const normalizedExpected = versionSpec
+    .replace(/\.x$/, '')
+    .replace(/\s+devel$/, '')
+    .trim()
 
   // Compare major.minor parts for compatibility
   const actualParts = normalizedActual.split('.')

--- a/src/install-xgo.ts
+++ b/src/install-xgo.ts
@@ -102,7 +102,23 @@ function install(xgoDir: string): void {
 function checkVersion(versionSpec: string): string {
   core.info(`Testing xgo ${versionSpec} ...`)
   const actualVersion = xgoVersion()
-  if (actualVersion !== versionSpec) {
+
+  // Normalize versions by removing common suffixes
+  // Examples: "1.5.x" -> "1.5", "1.6.0 devel" -> "1.6.0"
+  const normalizedActual = actualVersion
+    .replace(/\.x$/, '')
+    .replace(/\s+devel$/, '')
+    .trim()
+  const normalizedExpected = versionSpec.trim()
+
+  // Compare major.minor parts for compatibility
+  const actualParts = normalizedActual.split('.')
+  const expectedParts = normalizedExpected.split('.')
+  const minParts = Math.min(2, expectedParts.length)
+  const actualPrefix = actualParts.slice(0, minParts).join('.')
+  const expectedPrefix = expectedParts.slice(0, minParts).join('.')
+
+  if (actualPrefix !== expectedPrefix) {
     throw new Error(
       `Installed xgo version ${actualVersion} does not match expected version ${versionSpec}`
     )


### PR DESCRIPTION
## Summary

Fixes version comparison logic to handle different version formats returned by `xgo env XGOVERSION`.

## Problem

The version check was using strict string equality, which failed when:
- Old versions return `1.5.x` format
- New versions return `1.6.0 devel` format

This caused CI failures like:
```
Error: Installed xgo version 1.5.x does not match expected version 1.5.0
Error: Installed xgo version 1.6.0 devel does not match expected version 1.6.0
```

## Solution

Updated `checkVersion()` function to:

1. **Normalize versions** by removing common suffixes (`.x` and `devel`)
2. **Compare major.minor parts** instead of exact string match

This allows:
- `1.5.x` to match `1.5.0` ✅
- `1.6.0 devel` to match `1.6.0` ✅
- `1.5` to match `1.5.3` ✅

## Changes

- Modified `src/install-xgo.ts`: Updated `checkVersion()` function
- Rebuilt `dist/index.js`

## Testing

Will be verified by CI across multiple xgo versions (1, 1.5, 1.5.0, 1.6.0, latest, main).

## Notes

- Keeps using `cmd/make.go` for installation (no changes to build process)
- Minimal change, only affects version comparison logic